### PR TITLE
scripts,tests,utils: use env python3

### DIFF
--- a/scripts/gen-v4l2.py
+++ b/scripts/gen-v4l2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import unittest
 import v4l2

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import fcntl
 import gc

--- a/utils/cam.py
+++ b/utils/cam.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from __future__ import annotations
 

--- a/utils/mc-dot.py
+++ b/utils/mc-dot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import errno

--- a/utils/mc-print.py
+++ b/utils/mc-print.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import errno

--- a/utils/yuvconvgen.py
+++ b/utils/yuvconvgen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import ctypes
 import pprint


### PR DESCRIPTION
To make it easier for users with virtual environment for this project, use environment's python3 instead of hardcoding `/usr/bin/python3`