### PR TITLE
gen-v4l2.py: Handled packed structs

### DIFF
--- a/scripts/gen-v4l2.py
+++ b/scripts/gen-v4l2.py
@@ -50,12 +50,50 @@ def replace(filename, replaces):
         with open(filename, 'w', encoding='utf-8') as f:
             f.write(content)
 
+def find_packed_structs(headers):
+    """
+    Find packed structs in the given header files.
+
+    :param headers: List of header file paths.
+    :return: List of packed struct names.
+    """
+    packed_structs = []
+    pattern = re.compile(r'struct (\w+) {[^{}]*(?:{[^{}]*}[^{}]*)*} __attribute__ \(\(packed\)\);', re.DOTALL)
+
+    for header_file in headers:
+        with open(header_file, encoding='utf-8') as f:
+            content = f.read()
+            matches = pattern.findall(content)
+            packed_structs.extend(matches)
+
+    return packed_structs
+
+def add_pack_to_structs(filename, struct_names):
+    """
+    Add _pack_ = 1 to the specified structs in the v4l2 python binding
+
+    :param filename: The name of the Python file to modify.
+    :param struct_names: List of struct names to update.
+    """
+    replaces = []
+    for name in struct_names:
+        pattern = rf'^struct_{name}._fields_ = \['
+        replacement = f'struct_{name}._pack_ = 1\nstruct_{name}._fields_ = ['
+        replaces.append((pattern, replacement))
+
+    replace(filename, replaces)
+
 # Fix _IOC by using ord(type)
 
 replace(OUT, [
         (re.escape('return ((((dir << _IOC_DIRSHIFT) | (type << _IOC_TYPESHIFT)) | (nr << _IOC_NRSHIFT)) | (size << _IOC_SIZESHIFT))'),
          'return ((((dir << _IOC_DIRSHIFT) | (ord(type) << _IOC_TYPESHIFT)) | (nr << _IOC_NRSHIFT)) | (size << _IOC_SIZESHIFT))'),
         ])
+
+# Fix missing _pack_ attribute
+
+structs = find_packed_structs(INCLUDES)
+add_pack_to_structs(OUT, structs)
 
 # Add pylint ignore comment
 


### PR DESCRIPTION
ctypesgen failed to handle correctly packed struct when the packed attribute is at the end of the struct declaration (cf. [https://github.com/ctypesgen/ctypesgen/issues/218] ) 

This is a work around allowing to produce python bindings with the correct _pack_ attribute.
This commit should be reverted once the ctypesgen issue is fixed.

Bunch of regexp, could probably be improved ... However it seems to work (tested successfully with my headers).
Could you please replicate with your ctypesgen setup; I do not succeed to enable the '--no-macro-try-except' and '--no-source-comments' parameters.
If it's ok for you, could you please bump the new uapi/v4l2.py ?

Thanks in advance.