### PR TITLE
cam: Apply sensor controls in correct order relative to format setting

### DIFF
--- a/utils/cam/cam_helpers.py
+++ b/utils/cam/cam_helpers.py
@@ -185,8 +185,9 @@ def configure_subdevs(sctx: Subcontext, config):
 
         subdevices[ent.name] = subdev
 
-        if 'controls' in e:
-            for ctrl_id, ctrl_val in e['controls']:
+        # Configure controls that need to be set before format
+        if 'pre-controls' in e:
+            for ctrl_id, ctrl_val in e['pre-controls']:
                 subdev.set_control(ctrl_id, ctrl_val)
 
         # Configure routes
@@ -241,6 +242,12 @@ def configure_subdevs(sctx: Subcontext, config):
             if 'ival' in p:
                 assert(len(p['ival']) == 2)
                 subdev.set_frame_interval(pad, stream, p['ival'])
+
+        # Configure controls
+        if 'controls' in e:
+            for ctrl_id, ctrl_val in e['controls']:
+                subdev.set_control(ctrl_id, ctrl_val)
+
 
     return subdevices
 


### PR DESCRIPTION
Some sensor controls—such as VBLANK, HBLANK, and EXPOSURE have ranges
that depend on the active resolution and are updated by the driver when
a new format is set. To avoid having these values clamped or reset,
ensure they are applied after the format is configured.

Conversely, certain controls like VFLIP and HFLIP must be applied before
setting the format. To support this, introduce a pre-controls dictionary
in the configuration for controls that need to be set prior to the
format update.